### PR TITLE
OT-92 #9 IMAP and SMTP security setting is not used

### DIFF
--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -82,6 +82,13 @@ class Context {
   static const String configE2eeEnabled = "e2ee_enabled";
   static const String configQrOverlayLogo = "qr_overlay_logo";
 
+  static const int serverFlagsImapStartTls = 0x100;
+  static const int serverFlagsImapSsl = 0x200;
+  static const int serverFlagsImapPlain = 0x400;
+  static const int serverFlagsSmtpStartTls = 0x10000;
+  static const int serverFlagsSmtpSsl= 0x20000;
+  static const int serverFlagsSmtpPlain = 0x40000;
+
   final DeltaChatCore core = DeltaChatCore();
 
   Future<dynamic> getConfigValue(String key, [ObjectType type]) async {


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to improve or extend the code
title: ''
labels: ''
assignees: ''

---

**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/9

**Describe what the problem was / what the new feature is**
Missing constants for saving IMAP and SMTP security Options.

**Describe your solution**
Added missing constants

**Additional context**
Add any other context about the bug / feature here.
