### PR TITLE
OT-214 Allow updating of objects created by DCC

### DIFF
--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/AbstractCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/AbstractCallHandler.java
@@ -47,13 +47,13 @@ import com.b44t.messenger.DcContext;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 
-abstract class AbstractCallHandler {
+abstract public class AbstractCallHandler {
 
+    public static final String ARGUMENT_ID = "id";
     static final String ARGUMENT_TYPE = "type";
     static final String ARGUMENT_KEY = "key";
     static final String ARGUMENT_VALUE = "value";
     static final String ARGUMENT_ADDRESS = "address";
-    static final String ARGUMENT_ID = "id";
     static final String ARGUMENT_CACHE_ID = "cacheId";
     static final String ARGUMENT_VERIFIED = "verified";
     static final String ARGUMENT_NAME = "name";

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ChatCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ChatCallHandler.java
@@ -44,7 +44,6 @@ package com.openxchange.deltachatcore.handlers;
 
 import com.b44t.messenger.DcChat;
 import com.b44t.messenger.DcContext;
-import com.openxchange.deltachatcore.Cache;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -62,12 +61,10 @@ public class ChatCallHandler extends AbstractCallHandler {
     private static final String METHOD_CHAT_IS_SELF_TALK = "chat_isSelfTalk";
     private static final String METHOD_CHAT_IS_VERIFIED = "chat_isVerified";
 
-    private final Cache<DcChat> chatCache;
     private final ContextCallHandler contextCallHandler;
 
-    public ChatCallHandler(DcContext dcContext, Cache<DcChat> chatCache, ContextCallHandler contextCallHandler) {
+    public ChatCallHandler(DcContext dcContext, ContextCallHandler contextCallHandler) {
         super(dcContext);
-        this.chatCache = chatCache;
         this.contextCallHandler = contextCallHandler;
     }
 

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ContactCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ContactCallHandler.java
@@ -44,7 +44,6 @@ package com.openxchange.deltachatcore.handlers;
 
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
-import com.openxchange.deltachatcore.Cache;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -62,12 +61,10 @@ public class ContactCallHandler extends AbstractCallHandler {
     private static final String METHOD_CONTACT_IS_BLOCKED = "contact_isBlocked";
     private static final String METHOD_CONTACT_IS_VERIFIED = "contact_isVerified";
 
-    private final Cache<DcContact> contactCache;
     private final ContextCallHandler contextCallHandler;
 
-    public ContactCallHandler(DcContext dcContext, Cache<DcContact> contactCache, ContextCallHandler contextCallHandler) {
+    public ContactCallHandler(DcContext dcContext, ContextCallHandler contextCallHandler) {
         super(dcContext);
-        this.contactCache = contactCache;
         this.contextCallHandler = contextCallHandler;
     }
 

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
@@ -171,7 +171,7 @@ public class ContextCallHandler extends AbstractCallHandler {
                 getChatByContactId(methodCall, result);
                 break;
             case METHOD_GET_BLOCKED_CONTACTS:
-                getBlockedContacts(methodCall, result);
+                getBlockedContacts(result);
                 break;
             case METHOD_GET_FRESH_MESSAGE_COUNT:
                 getFreshMessageCount(methodCall, result);
@@ -447,7 +447,7 @@ public class ContextCallHandler extends AbstractCallHandler {
         result.success(contactIds);
     }
 
-    private void getBlockedContacts(MethodCall methodCall, MethodChannel.Result result) {
+    private void getBlockedContacts(MethodChannel.Result result) {
         int[] blockedIds = dcContext.getBlockedContacts();
         for (int blockedContactId : blockedIds) {
             loadAndCacheContact(blockedContactId);
@@ -673,8 +673,11 @@ public class ContextCallHandler extends AbstractCallHandler {
             resultErrorArgumentMissing(result);
             return;
         }
-
         Integer chatId = methodCall.argument(ARGUMENT_CHAT_ID);
+        if (chatId == null) {
+            resultErrorArgumentMissingValue(result);
+            return;
+        }
         ArrayList<Integer> msgIdArray = methodCall.argument(ARGUMENT_VALUE);
         if (msgIdArray == null) {
             resultErrorArgumentMissingValue(result);

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/EventChannelHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/EventChannelHandler.java
@@ -125,6 +125,7 @@ public class EventChannelHandler implements EventChannel.StreamHandler {
         eventSink = null;
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean hasListenersForId(int eventId) {
         return eventId != 0 && listeners.indexOfValue(eventId) >= 0;
     }

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/MessageCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/MessageCallHandler.java
@@ -44,7 +44,6 @@ package com.openxchange.deltachatcore.handlers;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcMsg;
-import com.openxchange.deltachatcore.Cache;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -80,11 +79,9 @@ public class MessageCallHandler extends AbstractCallHandler {
     private static final String METHOD_MESSAGE_SET_DURATION = "msg_setDuration";
     private static final String METHOD_MESSAGE_IS_OUTGOING = "msg_isOutgoing";
     private final ContextCallHandler contextCallHandler;
-    private Cache<DcMsg> messageCache;
 
-    public MessageCallHandler(DcContext dcContext, Cache<DcMsg> messageCache, ContextCallHandler contextCallHandler) {
+    public MessageCallHandler(DcContext dcContext, ContextCallHandler contextCallHandler) {
         super(dcContext);
-        this.messageCache = messageCache;
         this.contextCallHandler = contextCallHandler;
     }
 

--- a/lib/src/chat.dart
+++ b/lib/src/chat.dart
@@ -46,6 +46,8 @@ import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:delta_chat_core/src/base.dart';
 
 class Chat extends Base {
+  static const String _identifier = "chat";
+
   static const String methodChatGetId = "chat_getId";
   static const String methodChatIsGroup = "chat_isGroup";
   static const String methodChatGetArchived = "chat_getArchived";
@@ -68,48 +70,50 @@ class Chat extends Base {
 
   Chat._internal(this._id) : super();
 
-  int getId() {
-    return _id;
-  }
+  @override
+  int get id => _id;
+
+  @override
+  String get identifier => _identifier;
 
   Future<int> getChatId() async {
-    return await loadAndGetValue(methodChatGetId, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetId);
   }
 
   Future<bool> isGroup() async {
-    return await loadAndGetValue(methodChatIsGroup, getDefaultArguments());
+    return await loadAndGetValue(methodChatIsGroup);
   }
 
   Future<int> getArchived() async {
-    return await loadAndGetValue(methodChatGetArchived, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetArchived);
   }
 
   Future<int> getColor() async {
-    return await loadAndGetValue(methodChatGetColor, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetColor);
   }
 
   Future<String> getName() async {
-    return await loadAndGetValue(methodChatGetName, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetName);
   }
 
   Future<String> getSubtitle() async {
-    return await loadAndGetValue(methodChatGetSubtitle, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetSubtitle);
   }
 
   Future<String> getProfileImage() async {
-    return await loadAndGetValue(methodChatGetProfileImage, getDefaultArguments());
+    return await loadAndGetValue(methodChatGetProfileImage);
   }
 
   Future<bool> isUnpromoted() async {
-    return await loadAndGetValue(methodChatIsUnpromoted, getDefaultArguments());
+    return await loadAndGetValue(methodChatIsUnpromoted);
   }
 
   Future<bool> isVerified() async {
-    return await loadAndGetValue(methodChatIsVerified, getDefaultArguments());
+    return await loadAndGetValue(methodChatIsVerified);
   }
 
   Future<bool> isSelfTalk() async {
-    return await loadAndGetValue(methodChatIsSelfTalk, getDefaultArguments());
+    return await loadAndGetValue(methodChatIsSelfTalk);
   }
 
   @override

--- a/lib/src/chatlist.dart
+++ b/lib/src/chatlist.dart
@@ -46,6 +46,8 @@ import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:delta_chat_core/src/base.dart';
 
 class ChatList extends Base {
+  static const String _identifier = "chatList";
+
   static const String methodChatListInternalSetup = "chatList_internal_setup";
   static const String methodChatListInternalTearDown = "chatList_internal_tearDown";
   static const String methodChatListGetCnt = "chatList_getCnt";
@@ -66,6 +68,12 @@ class ChatList extends Base {
   final DeltaChatCore core = DeltaChatCore();
 
   int _id;
+
+  @override
+  int get id => _id;
+
+  @override
+  String get identifier => _identifier;
 
   Future<void> setup([int chatListType = typeNoSpecials]) async {
     _id = await core.invokeMethod(methodChatListInternalSetup, getSetupArguments(chatListType));
@@ -105,4 +113,5 @@ class ChatList extends Base {
   Map<String, dynamic> getSetupArguments(int chatListType) => <String, dynamic>{Base.argumentType: chatListType};
 
   Map<String, dynamic> getIndexArguments(int index) => <String, dynamic>{Base.argumentCacheId: _id, Base.argumentIndex: index};
+
 }

--- a/lib/src/chatmsg.dart
+++ b/lib/src/chatmsg.dart
@@ -44,7 +44,9 @@ import 'dart:async';
 
 import 'package:delta_chat_core/src/base.dart';
 
-class ChatMsg extends Base{
+class ChatMsg extends Base {
+  static const String _identifier = "chatMessage";
+
   static const String methodMessageGetId = "msg_getId";
   static const String methodMessageGetText = "msg_getText";
   static const String methodMessageGetTimestamp = "msg_getTimestamp";
@@ -91,60 +93,62 @@ class ChatMsg extends Base{
 
   ChatMsg._internal(this._id) : super();
 
-  int getId() {
-    return _id;
-  }
+  @override
+  int get id => _id;
+
+  @override
+  String get identifier => _identifier;
 
   Future<int> getMessageId() async {
-    return await loadAndGetValue(methodMessageGetId, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetId);
   }
 
   Future<String> getText() async {
-    return await loadAndGetValue(methodMessageGetText, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetText);
   }
 
   Future<int> getTimestamp() async {
-    return await loadAndGetValue(methodMessageGetTimestamp, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetTimestamp);
   }
 
   Future<int> getChatId() async {
-    return await loadAndGetValue(methodMessageGetChatId, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetChatId);
   }
 
   Future<int> getFromId() async {
-    return await loadAndGetValue(methodMessageGetFromId, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetFromId);
   }
 
   Future<bool> isOutgoing() async {
-    return await loadAndGetValue(methodMessageIsOutgoing, getDefaultArguments());
+    return await loadAndGetValue(methodMessageIsOutgoing);
   }
 
   Future<bool> hasFile() async {
-    return await loadAndGetValue(methodMessageHasFile, getDefaultArguments());
+    return await loadAndGetValue(methodMessageHasFile);
   }
 
   Future<int> getType() async {
-    return await loadAndGetValue(methodMessageGetType, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetType);
   }
 
   Future<String> getFile() async {
-    return await loadAndGetValue(methodMessageGetFile, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetFile);
   }
 
   Future<int> getFileBytes() async {
-    return await loadAndGetValue(methodMessageGetFileBytes, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetFileBytes);
   }
 
   Future<String> getFileName() async {
-    return await loadAndGetValue(methodMessageGetFilename, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetFilename);
   }
 
   Future<String> getFileMime() async {
-    return await loadAndGetValue(methodMessageGetFileMime, getDefaultArguments());
+    return await loadAndGetValue(methodMessageGetFileMime);
   }
 
   Future<String> getSummaryText(int characterCount) async {
-    return await loadAndGetValue(methodMessageGetSummaryText, getSummaryArguments(characterCount));
+    return await loadAndGetValue(methodMessageGetSummaryText, arguments: getSummaryArguments(characterCount));
   }
 
   @override
@@ -155,5 +159,4 @@ class ChatMsg extends Base{
   static Function getCreator() {
     return (id) => new ChatMsg._internal(id);
   }
-
 }

--- a/lib/src/contact.dart
+++ b/lib/src/contact.dart
@@ -45,6 +45,8 @@ import 'dart:async';
 import 'package:delta_chat_core/src/base.dart';
 
 class Contact extends Base {
+  static const String _identifier = "contact";
+
   static const String methodContactGetId = "contact_getId";
   static const String methodContactGetName = "contact_getName";
   static const String methodContactGetDisplayName = "contact_getDisplayName";
@@ -64,44 +66,46 @@ class Contact extends Base {
 
   Contact._internal(this._id) : super();
 
-  int getId() {
-    return _id;
-  }
+  @override
+  int get id => _id;
+
+  @override
+  String get identifier => _identifier;
 
   Future<String> getName() async {
-    return await loadAndGetValue(methodContactGetName, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetName);
   }
 
   Future<String> getDisplayName() async {
-    return await loadAndGetValue(methodContactGetDisplayName, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetDisplayName);
   }
 
   Future<String> getFirstName() async {
-    return await loadAndGetValue(methodContactGetFirstName, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetFirstName);
   }
 
   Future<String> getAddress() async {
-    return await loadAndGetValue(methodContactGetAddress, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetAddress);
   }
 
   Future<String> getNameAndAddress() async {
-    return await loadAndGetValue(methodContactGetNameAndAddress, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetNameAndAddress);
   }
 
   Future<String> getProfileImage() async {
-    return await loadAndGetValue(methodContactGetProfileImage, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetProfileImage);
   }
 
   Future<int> getColor() async {
-    return await loadAndGetValue(methodContactGetColor, getDefaultArguments());
+    return await loadAndGetValue(methodContactGetColor);
   }
 
   Future<bool> isVerified() async {
-    return await loadAndGetValue(methodContactIsVerified, getDefaultArguments());
+    return await loadAndGetValue(methodContactIsVerified);
   }
 
   Future<bool> isBlocked() async {
-    return await loadAndGetValue(methodContactIsBlocked, getDefaultArguments());
+    return await loadAndGetValue(methodContactIsBlocked);
   }
 
   Map<String, dynamic> getDefaultArguments() => <String, dynamic>{Base.argumentId: _id};

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -233,7 +233,7 @@ class Context {
   Future<List<int>> getFreshMessages() async {
     return await core.invokeMethod(methodGetFreshMessages);
   }
-  
+
   Future<void> forwardMessages(int chatId, List<int> msgIds) async {
     return await core.invokeMethod(methodForwardMessages, getForwardMessageArguments(chatId, msgIds));
   }
@@ -270,5 +270,6 @@ class Context {
 
   Map<String, dynamic> getExportImportArguments(String path) => <String, dynamic>{Base.argumentPath: path};
 
-  Map<String, dynamic> getForwardMessageArguments(int chatId, List<int> msgIds) => <String, dynamic>{Base.argumentChatId: chatId, Base.argumentValue: msgIds};
+  Map<String, dynamic> getForwardMessageArguments(int chatId, List<int> msgIds) =>
+      <String, dynamic>{Base.argumentChatId: chatId, Base.argumentValue: msgIds};
 }


### PR DESCRIPTION
- Multiple smaller renamings
- Clean ups
- Fixed warnings (e.g. NPE)
- android/src/main/java/com/openxchange/deltachatcore/DeltaChatCorePlugin.java - https://github.com/open-xchange/flutter-deltachat-core/compare/OT-214?expand=1#diff-01b888410f9b6d3bca5791cc67675e41
  - Added the removing of objects from the Java cache if required by the Dart call
- lib/src/base.dart - https://github.com/open-xchange/flutter-deltachat-core/compare/OT-214?expand=1#diff-c696616286e484353e643d9bad235f19
  - Added reloadValue and reloadValues. Those methods allow reloading of values, which internally triggers the loading of a new DCC object and a refresh of our Java cache
  