### PR TITLE
OT-479 #45 Fixed wrong return value for chats from contacts

### DIFF
--- a/ios/Classes/Handler/ContextCallHandler.swift
+++ b/ios/Classes/Handler/ContextCallHandler.swift
@@ -400,7 +400,7 @@ class ContextCallHandler: MethodCallHandling {
     fileprivate func getChatByContactId(methodCall: FlutterMethodCall, result: FlutterResult) {
         let contactId = UInt32(methodCall.intValue(for: Argument.CONTACT_ID, result: result))
         guard let chat = context.getChatByContactId(contactId: contactId) else {
-            result(NSNull())
+            result(NSNumber(value: 0))
             return
         }
         result(NSNumber(value: chat.id))


### PR DESCRIPTION
**Link to the given issue**
#45 

**Describe what the problem was / what the new feature is**
Unlimited spinner in Contactview while importing contacts

**Describe your solution**
Changing return value of chatId from "null" to "0" if no chat exists for contact

