### PR TITLE
Updated to NDK 20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,11 +25,11 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
-            abiFilters 'armeabi-v7a' ,'x86', 'arm64-v8a'
+            abiFilters 'armeabi-v7a' ,'x86', 'arm64-v8a', 'x86_64'
         }
     }
     lintOptions {

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -20,13 +20,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE     := native-utils
 
 LOCAL_C_INCLUDES := $(JNI_DIR)/utils/
-LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz -latomic
+LOCAL_LDLIBS 	:= -ljnigraphics -llog -lz
 LOCAL_STATIC_LIBRARIES :=  deltachat-core
-# if you get "undefined reference" errors, the reason for this may be the _order_! Eg. libiconv as the first library does not work!
-# "breakpad" was placed after "crypto", NativeLoader.cpp after dc_wrapper.c
 
 LOCAL_CFLAGS 	:= -w -Os -DNULL=0 -DSOCKLEN_T=socklen_t -DLOCALE_NOT_USED -D_LARGEFILE_SOURCE=1 -D_FILE_OFFSET_BITS=64
-LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno -std=c99
+LOCAL_CFLAGS 	+= -Drestrict='' -D__EMX__ -DOPUS_BUILD -DFIXED_POINT -DUSE_ALLOCA -DHAVE_LRINT -DHAVE_LRINTF -fno-math-errno
 LOCAL_CFLAGS 	+= -DANDROID_NDK -DDISABLE_IMPORTGL -fno-strict-aliasing -fprefetch-loop-arrays -DAVOID_TABLES -DANDROID_TILE_BASED_DECODE -DANDROID_ARMV6_IDCT -ffast-math -D__STDC_CONSTANT_MACROS
 
 LOCAL_SRC_FILES := \

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,5 +1,3 @@
-APP_PLATFORM := android-14
-APP_ABI := arm64-v8a armeabi-v7a x86
-NDK_TOOLCHAIN_VERSION := 4.9
-APP_STL := gnustl_static
-
+APP_PLATFORM := android-21
+APP_ABI := arm64-v8a armeabi-v7a x86 x86_64
+APP_STL := c++_static

--- a/android/ndk-make.sh
+++ b/android/ndk-make.sh
@@ -1,34 +1,39 @@
+#!/bin/sh
+
+set -e
+
 echo -- cross compiling --
 cd jni/deltachat-core-rust
 
 # to setup the toolchains (from https://medium.com/visly/rust-on-android-19f34a2fb43 )
-# $ rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android
-# $ mkdir ~/.NDK
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 21 --arch arm64 --install-dir ~/.NDK/arm64
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 14 --arch arm --install-dir ~/.NDK/arm
-# $ $ANDROID_NDK/build/tools/make_standalone_toolchain.py --api 14 --arch x86 --install-dir ~/.NDK/x86
-# (--api should be aligned with APP_PLATFORM from Application.mk and with minSdkVersion)
-# this installs toolchains in `~/.NDK`, make sure, the subdirs are in the $PATH variable.
+# $ rustup target add aarch64-linux-android armv7-linux-androideabi \
+#                     i686-linux-android x86_64-linux-android
+# add $NDK/toolchains/llvm/prebuilt/linux-x86_64/bin to your $PATH
+# where linux-x86_64 depends on your host OS
 # then, the following should work:
 
+export CFLAGS=-D__ANDROID_API__=21
+
+TARGET_CC=aarch64-linux-android21-clang \
 cargo build --release --target aarch64-linux-android -p deltachat_ffi
+TARGET_CC=armv7a-linux-androideabi21-clang \
 cargo build --release --target armv7-linux-androideabi -p deltachat_ffi
+TARGET_CC=i686-linux-android21-clang \
 cargo build --release --target i686-linux-android -p deltachat_ffi
+TARGET_CC=x86_64-linux-android21-clang \
+cargo build --release --target x86_64-linux-android -p deltachat_ffi
 
 # an alternative might be:
 # $ cross build --release --target <target> -p deltachat_ffi
 
 echo -- copy generated .a files --
 cd ..
-rm arm64-v8a/*
-rm armeabi-v7a/*
-rm x86/*
-mkdir -p arm64-v8a
-mkdir -p armeabi-v7a
-mkdir -p x86
+rm -rf   arm64-v8a armeabi-v7a x86 x86_64
+mkdir -p arm64-v8a armeabi-v7a x86 x86_64
 cp deltachat-core-rust/target/aarch64-linux-android/release/libdeltachat.a arm64-v8a
 cp deltachat-core-rust/target/armv7-linux-androideabi/release/libdeltachat.a armeabi-v7a
 cp deltachat-core-rust/target/i686-linux-android/release/libdeltachat.a x86
+cp deltachat-core-rust/target/x86_64-linux-android/release/libdeltachat.a x86_64
 
 echo -- ndk-build --
 cd ..

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
 
     defaultConfig {
         applicationId "com.openxchange.deltachatcoreexample"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
**Describe what the problem was / what the new feature is**
NDK 14, which we use to build native code on Android is not supported anymore.

**Describe your solution**
Updated everything to be compatible with the latest NDK version. Since we only require Android 5.0, also updated all API versions to API 21. This is required for 64 bits anyway.

Also added x86_64 since nowadays Google Play requires 64 bit support for every supported 32 bit architecture.