### PR TITLE
Events aren't delegated to the Flutter plugin #59

### DIFF
--- a/android/src/main/java/com/openxchange/deltachatcore/DeltaChatCorePlugin.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/DeltaChatCorePlugin.java
@@ -68,7 +68,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.FlutterNativeView;
 
 public class DeltaChatCorePlugin implements MethodCallHandler, PluginRegistry.ViewDestroyListener {
-    public static final String TAG = "coi";
+    static final String TAG = "coi";
 
     private static final String LIBRARY_NAME = "native-utils";
     private static final String CHANNEL_DELTA_CHAT_CORE = "deltaChatCore";
@@ -83,13 +83,10 @@ public class DeltaChatCorePlugin implements MethodCallHandler, PluginRegistry.Vi
 
     private static final String METHOD_BASE_INIT = "base_init";
     private static final String METHOD_BASE_SYSTEM_INFO = "base_systemInfo";
-    private static final String METHOD_BASE_CORE_LISTENER = "base_coreListener";
     private static final String METHOD_BASE_SET_CORE_STRINGS = "base_setCoreStrings";
     private static final String METHOD_BASE_START = "base_start";
     private static final String METHOD_BASE_STOP = "base_stop";
 
-    private static final String ARGUMENT_ADD = "add";
-    private static final String ARGUMENT_EVENT_ID = "eventId";
     private static final String ARGUMENT_REMOVE_CACHE_IDENTIFIER = "removeCacheIdentifier";
     private static final String ARGUMENT_DB_NAME = "dbName";
 
@@ -111,6 +108,7 @@ public class DeltaChatCorePlugin implements MethodCallHandler, PluginRegistry.Vi
     private ContactCallHandler contactCallHandler;
     private ContextCallHandler contextCallHandler;
     private MessageCallHandler messageCallHandler;
+    @SuppressWarnings("FieldCanBeLocal")
     private EventChannelHandler eventChannelHandler;
 
     private DeltaChatCorePlugin(Registrar registrar) {
@@ -189,9 +187,6 @@ public class DeltaChatCorePlugin implements MethodCallHandler, PluginRegistry.Vi
             case METHOD_BASE_SYSTEM_INFO:
                 systemInfo(result);
                 break;
-            case METHOD_BASE_CORE_LISTENER:
-                coreListener(methodCall, result);
-                break;
             case METHOD_BASE_SET_CORE_STRINGS:
                 setCoreStrings(methodCall, result);
                 break;
@@ -230,21 +225,6 @@ public class DeltaChatCorePlugin implements MethodCallHandler, PluginRegistry.Vi
 
     private void systemInfo(Result result) {
         result.success(android.os.Build.VERSION.RELEASE);
-    }
-
-    private void coreListener(MethodCall methodCall, Result result) {
-        Boolean add = methodCall.argument(ARGUMENT_ADD);
-        Integer eventId = methodCall.argument(ARGUMENT_EVENT_ID);
-        if (eventId == null || add == null) {
-            return;
-        }
-        if (add) {
-            eventChannelHandler.addListener(eventId);
-            result.success(null);
-        } else {
-            eventChannelHandler.removeListener(eventId);
-            result.success(null);
-        }
     }
 
     private void start(Result result) {

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/EventChannelHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/EventChannelHandler.java
@@ -42,8 +42,7 @@
 
 package com.openxchange.deltachatcore.handlers;
 
-import android.util.SparseIntArray;
-
+import com.b44t.messenger.DcContext;
 import com.openxchange.deltachatcore.Utils;
 
 import java.util.Arrays;
@@ -55,8 +54,32 @@ import io.flutter.plugin.common.EventChannel;
 public class EventChannelHandler implements EventChannel.StreamHandler {
 
     private static final String CHANNEL_DELTA_CHAT_CORE_EVENTS = "deltaChatCoreEvents";
+    // Must match all events listed in android/src/main/java/com/b44t/messenger/DcContext.java (DC_EVENT_*)
+    private final static List<Integer> DELEGATE_EVENTS = Arrays.asList(DcContext.DC_EVENT_INFO,
+            DcContext.DC_EVENT_WARNING,
+            DcContext.DC_EVENT_ERROR,
+            DcContext.DC_EVENT_ERROR_NETWORK,
+            DcContext.DC_EVENT_ERROR_SELF_NOT_IN_GROUP,
+            DcContext.DC_EVENT_MSGS_CHANGED,
+            DcContext.DC_EVENT_INCOMING_MSG,
+            DcContext.DC_EVENT_MSG_DELIVERED,
+            DcContext.DC_EVENT_MSG_FAILED,
+            DcContext.DC_EVENT_MSG_READ,
+            DcContext.DC_EVENT_CHAT_MODIFIED,
+            DcContext.DC_EVENT_CONTACTS_CHANGED,
+            DcContext.DC_EVENT_LOCATION_CHANGED,
+            DcContext.DC_EVENT_CONFIGURE_PROGRESS,
+            DcContext.DC_EVENT_IMEX_PROGRESS,
+            DcContext.DC_EVENT_IMEX_FILE_WRITTEN,
+            DcContext.DC_EVENT_SECUREJOIN_INVITER_PROGRESS,
+            DcContext.DC_EVENT_SECUREJOIN_JOINER_PROGRESS,
+            DcContext.DC_EVENT_IS_OFFLINE,
+            DcContext.DC_EVENT_GET_STRING,
+            DcContext.DC_EVENT_GET_QUANTITIY_STRING,
+            DcContext.DC_EVENT_HTTP_GET,
+            DcContext.DC_EVENT_HTTP_POST);
+
     private EventChannel.EventSink eventSink;
-    private SparseIntArray listeners = new SparseIntArray();
 
     public EventChannelHandler(BinaryMessenger messenger) {
         EventChannel eventChannel = new EventChannel(messenger, CHANNEL_DELTA_CHAT_CORE_EVENTS);
@@ -65,40 +88,16 @@ public class EventChannelHandler implements EventChannel.StreamHandler {
 
     public void handleEvent(int eventId, Object data1, Object data2) {
         List<Object> result = Arrays.asList(eventId, data1, data2);
-        if (!hasListenersForId(eventId)) {
+        if (!isDelegateEvent(eventId)) {
             return;
         }
         Utils.runOnMain(() -> {
             try {
                 eventSink.success(result);
-            }
-            catch(Exception e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         });
-    }
-
-    public void addListener(Integer eventId) {
-        if (eventId == null) {
-            return;
-        }
-        int counter = listeners.get(eventId) + 1;
-        updateListenerCounter(eventId, counter);
-    }
-
-    public void removeListener(Integer eventId) {
-        if (eventId == null) {
-            return;
-        }
-        int counter = listeners.get(eventId) - 1;
-        updateListenerCounter(eventId, counter);
-    }
-
-    private void updateListenerCounter(Integer eventId, int counter) {
-        if (counter < 0) {
-            counter = 0;
-        }
-        listeners.put(eventId, counter);
     }
 
     @Override
@@ -118,7 +117,7 @@ public class EventChannelHandler implements EventChannel.StreamHandler {
         eventSink = null;
     }
 
-    private boolean hasListenersForId(int eventId) {
-        return eventId != 0 && listeners.get(eventId) > 0;
+    private boolean isDelegateEvent(int eventId) {
+        return DELEGATE_EVENTS.contains(eventId);
     }
 }

--- a/lib/delta_chat_core.dart
+++ b/lib/delta_chat_core.dart
@@ -63,13 +63,10 @@ class DeltaChatCore {
   static const String channelDeltaChatCoreEvents = 'deltaChatCoreEvents';
 
   static const String methodBaseInit = 'base_init';
-  static const String methodBaseCoreListener = "base_coreListener";
   static const String methodBaseSetCoreStrings = "base_setCoreStrings";
   static const String methodBaseStart = "base_start";
   static const String methodBaseStop = "base_stop";
 
-  static const String argumentAdd = "add";
-  static const String argumentEventId = "eventId";
   static const String argumentDBName = "dbName";
 
   static DeltaChatCore _instance;
@@ -141,7 +138,6 @@ class DeltaChatCore {
     if (eventId == null || streamController == null) {
       return;
     }
-    await invokeMethod(methodBaseCoreListener, <String, dynamic>{argumentAdd: true, argumentEventId: eventId});
     var eventIdSubscribers = _eventChannelSubscribers[eventId];
     if (eventIdSubscribers == null) {
       eventIdSubscribers = Map();
@@ -153,7 +149,7 @@ class DeltaChatCore {
   delegateEventToSubscribers(Event event) {
     var logMessage = "Event - id: ${event.eventId}, data1: ${event.data1}, data2: ${event.data2}";
     _logger.fine(logMessage);
-    _eventChannelSubscribers[event.eventId].forEach((_, streamController) {
+    _eventChannelSubscribers[event.eventId]?.forEach((_, streamController) {
       streamController.add(event);
     });
   }
@@ -168,7 +164,6 @@ class DeltaChatCore {
     streamController.close();
     var eventIdSubscribers = _eventChannelSubscribers[eventId];
     eventIdSubscribers?.remove(hashCode);
-    await invokeMethod(methodBaseCoreListener, <String, dynamic>{argumentAdd: false, argumentEventId: eventId});
   }
 
   // Manually adds events to the core stream. This shouldn't be required normally, as those events should be produced / captured by the

--- a/lib/src/types/event.dart
+++ b/lib/src/types/event.dart
@@ -44,6 +44,8 @@ class Event {
   static const int info = 100;
   static const int warning = 300;
   static const int error = 400;
+  static const int errorNoNetwork = 401;
+  static const int errorNotInGroup = 410;
   static const int msgsChanged = 2000;
   static const int incomingMsg = 2005;
   static const int msgDelivered = 2010;
@@ -51,6 +53,7 @@ class Event {
   static const int msgRead = 2015;
   static const int chatModified = 2020;
   static const int contactsChanged = 2030;
+  static const int locationChanged = 2035;
   static const int configureProgress = 2041;
   static const int imexProgress = 2051;
   static const int imexFileWrite = 2052;
@@ -62,6 +65,7 @@ class Event {
   static const int getString = 2091;
   static const int getQuantityString = 2092;
   static const int httpGet = 2100;
+  static const int httpPost = 2110;
 
   static const indexEventId = 0;
   static const indexData1 = 1;


### PR DESCRIPTION
**Link to the given issue**
#59 

**Describe what the problem was / what the new feature is**
Events were lost in some situations as the listener registration took to long.

**Describe your solution**
Removed the whole native "_keep track of listeners_" part and added a "_delegate all potentially important events to Flutter_" part. On the Flutter side we filter events anyway. The logic delegates only known events the app potentially can be interested in, all other events aren't delegated.

**Additional context**
Added some events which were missing in the list of ids.
