### PR TITLE
Events not handled correctly ox-coi/334

### DIFF
--- a/lib/src/types/event.dart
+++ b/lib/src/types/event.dart
@@ -67,6 +67,8 @@ class Event {
   static const int httpGet = 2100;
   static const int httpPost = 2110;
 
+  static const allErrorsList = [error, errorNoNetwork, errorNotInGroup];
+
   static const indexEventId = 0;
   static const indexData1 = 1;
   static const indexData2 = 2;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author:
 homepage:
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/334

**Describe what the problem was / what the new feature is**
The even list registration / deregistration wasn't reliable.

**Describe your solution**

- Listening to one or many events with one call is possible
- Removal of a listener is possible with just the stream handler

**Additional context**

- Added a check to avoid multiple add listener calls for one stream handler, if one handler should listen to multiple events just pass them during initialization
- Simplified the removal (no event ids are required anymore, all connections will be closed)
- Added error messages if wrongly used
- Removed unused error callback
- Updated the minimum Dart version
