### PR TITLE
OT-598 No Option to add an unblocked unknown user to contacts

### DIFF
--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
@@ -111,7 +111,7 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
     private static final String METHOD_SET_COI_MESSAGE_FILTER = "context_setCoiMessageFilter";
     private static final String METHOD_GET_MESSAGE_INFO = "context_getMessageInfo";
     private static final String METHOD_RETRY_SENDING_PENDING_MESSAGES = "context_retrySendingPendingMessages";
-    private static final String METHOD_IS_KNOWN_CONTACT = "context_isKnownContact";
+    private static final String METHOD_GET_CONTACT_ID_BY_ADDRESS = "context_getContactIdByAddress";
 
     private static final String TYPE_INT = "int";
     private static final String TYPE_STRING = "String";
@@ -295,8 +295,8 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
             case METHOD_RETRY_SENDING_PENDING_MESSAGES:
                 retrySendingPendingMessages(result);
                 break;
-            case METHOD_IS_KNOWN_CONTACT:
-                isKnownContact(methodCall, result);
+            case METHOD_GET_CONTACT_ID_BY_ADDRESS:
+                getContactIdByAddress(methodCall, result);
                 break;
             default:
                 result.notImplemented();
@@ -1115,15 +1115,15 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
         result.success(messageInfo);
     }
 
-    private void isKnownContact(MethodCall methodCall, MethodChannel.Result result) {
+    private void getContactIdByAddress(MethodCall methodCall, MethodChannel.Result result) {
         String address = methodCall.argument(ARGUMENT_ADDRESS);
         if (address == null || address.isEmpty()) {
             resultErrorArgumentMissingValue(result);
             return;
         }
 
-        int isKnownContact = dcContext.lookupContactIdByAddr(address);
-        result.success(isKnownContact == 1);
+        int contactId = dcContext.lookupContactIdByAddr(address);
+        result.success(contactId);
     }
 
     private void retrySendingPendingMessages(MethodChannel.Result result) {

--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
@@ -111,6 +111,7 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
     private static final String METHOD_SET_COI_MESSAGE_FILTER = "context_setCoiMessageFilter";
     private static final String METHOD_GET_MESSAGE_INFO = "context_getMessageInfo";
     private static final String METHOD_RETRY_SENDING_PENDING_MESSAGES = "context_retrySendingPendingMessages";
+    private static final String METHOD_IS_KNOWN_CONTACT = "context_isKnownContact";
 
     private static final String TYPE_INT = "int";
     private static final String TYPE_STRING = "String";
@@ -293,6 +294,9 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
                 break;
             case METHOD_RETRY_SENDING_PENDING_MESSAGES:
                 retrySendingPendingMessages(result);
+                break;
+            case METHOD_IS_KNOWN_CONTACT:
+                isKnownContact(methodCall, result);
                 break;
             default:
                 result.notImplemented();
@@ -1109,6 +1113,17 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
 
         String messageInfo = dcContext.getMsgInfo(messageId);
         result.success(messageInfo);
+    }
+
+    private void isKnownContact(MethodCall methodCall, MethodChannel.Result result) {
+        String address = methodCall.argument(ARGUMENT_ADDRESS);
+        if (address == null || address.isEmpty()) {
+            resultErrorArgumentMissingValue(result);
+            return;
+        }
+
+        int isKnownContact = dcContext.lookupContactIdByAddr(address);
+        result.success(isKnownContact == 1);
     }
 
     private void retrySendingPendingMessages(MethodChannel.Result result) {

--- a/ios/Classes/DCWrapper/DCContext.swift
+++ b/ios/Classes/DCWrapper/DCContext.swift
@@ -215,6 +215,10 @@ class DcContext {
     func createContact(name: String, emailAddress: String) -> UInt32 {
         return dc_create_contact(DcContext.contextPointer, name, emailAddress)
     }
+    
+    func lookupContactIdByAddr(addr: String) -> UInt32 {
+        return dc_lookup_contact_id_by_addr(DcContext.contextPointer,  addr)
+    }
 
     // MARK: - Addressbook
 

--- a/ios/Classes/Handler/ContextCallHandler.swift
+++ b/ios/Classes/Handler/ContextCallHandler.swift
@@ -168,6 +168,8 @@ class ContextCallHandler: MethodCallHandling {
             getMessageInfo(methodCall: call, result: result)
         case Method.Context.RETRY_SENDING_PENDING_MESSAGES:
             retrySendingPendingMessages(result: result)
+        case Method.Context.GET_CONTACT_ID_BY_ADDRESS:
+            getContactIdByAddress(methodCall: call, result: result)
         default:
             log.error("Context: Failing for \(call.method)")
             result(FlutterMethodNotImplemented)
@@ -289,6 +291,13 @@ class ContextCallHandler: MethodCallHandling {
         let buffer = contactIds.withUnsafeBufferPointer { Data(buffer: $0) }
 
         result(FlutterStandardTypedData(int32: buffer))
+    }
+    
+    fileprivate func getContactIdByAddress(methodCall: FlutterMethodCall, result: FlutterResult) {
+        let address = methodCall.stringValue(for: Argument.ADDRESS, result: result)
+        let contactID = context.lookupContactIdByAddr(addr: address!)
+        
+        result(contactID)
     }
 
     // MARK: - Chat Related

--- a/ios/Classes/Handler/ContextCallHandler.swift
+++ b/ios/Classes/Handler/ContextCallHandler.swift
@@ -294,8 +294,11 @@ class ContextCallHandler: MethodCallHandling {
     }
     
     fileprivate func getContactIdByAddress(methodCall: FlutterMethodCall, result: FlutterResult) {
-        let address = methodCall.stringValue(for: Argument.ADDRESS, result: result)
-        let contactID = context.lookupContactIdByAddr(addr: address!)
+        guard let address = methodCall.stringValue(for: Argument.ADDRESS, result: result) else {
+            Method.Error.missingArgumentValue(for: Argument.ADDRESS, result: result)
+            return
+        }
+        let contactID = context.lookupContactIdByAddr(addr: address)
         
         result(contactID)
     }

--- a/ios/Classes/Helper/Method.swift
+++ b/ios/Classes/Helper/Method.swift
@@ -213,6 +213,7 @@ extension Method {
         static let SET_COI_MESSAGE_FILTER               = "context_setCoiMessageFilter"
         static let GET_MESSAGE_INFO                     = "context_getMessageInfo"
         static let RETRY_SENDING_PENDING_MESSAGES       = "context_retrySendingPendingMessages"
+        static let GET_CONTACT_ID_BY_ADDRESS                     = "context_getContactIdByAddress"
     }
 
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -102,6 +102,8 @@ class Context {
   static const String methodSetCoiMessageFilter = "context_setCoiMessageFilter";
   static const String methodGetMessageInfo = "context_getMessageInfo";
   static const String methodRetrySendingPendingMessages = "context_retrySendingPendingMessages";
+  static const String methodIsKnownContact = "context_isKnownContact";
+
 
   static const String configAddress = "addr";
   static const String configMailServer = "mail_server";
@@ -367,7 +369,7 @@ class Context {
   Future<void> getWebPushSubscription(String uid, int id) async {
     return await core.invokeMethod(methodGetWebPushSubscription, getWebPushGetSubscriptionArguments(uid, id));
   }
-  
+
   Future<void> setCoiEnabled(int enable, int id) async {
     return await core.invokeMethod(methodSetCoiEnabled, getSetCoiEnabledArguments(enable, id));
   }
@@ -382,6 +384,10 @@ class Context {
 
   Future<void> retrySendingPendingMessages() async {
     return await core.invokeMethod(methodRetrySendingPendingMessages);
+  }
+
+  Future<bool> isKnownContact(String address) async {
+    return await core.invokeMethod(methodIsKnownContact, getContactKnownArguments(address));
   }
 
   Map<String, dynamic> getKeyArguments(String key) => <String, dynamic>{Base.argumentKey: key};
@@ -439,7 +445,7 @@ class Context {
   Map<String, dynamic> getSetNameOrImageArguments(int chatId, String newValue) => <String, dynamic>{Base.argumentChatId: chatId, Base.argumentValue: newValue};
 
   Map<String, dynamic> getWebPushSubscribeArguments(String uid, String json, int id) => <String, dynamic>{Base.argumentUid: uid, Base.argumentJson: json, Base.argumentId: id};
-  
+
   Map<String, dynamic> getWebPushValidateArguments(String uid, String message, int id) => <String, dynamic>{Base.argumentUid: uid, Base.argumentMessage: message, Base.argumentId: id};
 
   Map<String, dynamic> getWebPushGetSubscriptionArguments(String uid, int id) => <String, dynamic>{Base.argumentUid: uid, Base.argumentId: id};
@@ -447,4 +453,6 @@ class Context {
   Map<String, dynamic> getSetCoiEnabledArguments(int enable, int id) => <String, dynamic>{Base.argumentEnable: enable, Base.argumentId: id};
 
   Map<String, dynamic> getSetCoiMessageFilter(int mode, int id) => <String, dynamic>{Base.argumentMode: mode, Base.argumentId: id};
+
+  Map<String, dynamic> getContactKnownArguments(String address) => <String, dynamic>{Base.argumentAddress: address};
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -102,7 +102,7 @@ class Context {
   static const String methodSetCoiMessageFilter = "context_setCoiMessageFilter";
   static const String methodGetMessageInfo = "context_getMessageInfo";
   static const String methodRetrySendingPendingMessages = "context_retrySendingPendingMessages";
-  static const String methodIsKnownContact = "context_isKnownContact";
+  static const String methodGetContactIdByAddress = "context_getContactIdByAddress";
 
 
   static const String configAddress = "addr";
@@ -386,8 +386,8 @@ class Context {
     return await core.invokeMethod(methodRetrySendingPendingMessages);
   }
 
-  Future<bool> isKnownContact(String address) async {
-    return await core.invokeMethod(methodIsKnownContact, getContactKnownArguments(address));
+  Future<bool> getContactIdByAddress(String address) async {
+    return await core.invokeMethod(methodGetContactIdByAddress, getContactIdByAddressArguments(address));
   }
 
   Map<String, dynamic> getKeyArguments(String key) => <String, dynamic>{Base.argumentKey: key};
@@ -454,5 +454,5 @@ class Context {
 
   Map<String, dynamic> getSetCoiMessageFilter(int mode, int id) => <String, dynamic>{Base.argumentMode: mode, Base.argumentId: id};
 
-  Map<String, dynamic> getContactKnownArguments(String address) => <String, dynamic>{Base.argumentAddress: address};
+  Map<String, dynamic> getContactIdByAddressArguments(String address) => <String, dynamic>{Base.argumentAddress: address};
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -386,7 +386,7 @@ class Context {
     return await core.invokeMethod(methodRetrySendingPendingMessages);
   }
 
-  Future<bool> getContactIdByAddress(String address) async {
+  Future<int> getContactIdByAddress(String address) async {
     return await core.invokeMethod(methodGetContactIdByAddress, getContactIdByAddressArguments(address));
   }
 


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-598 (internal ticket only)

**Describe what the problem was / what the new feature is**
The method to lookup valid contact (known and unblocked) was missing. 

**Describe your solution**
Added the method for Android.

**Additional context**
@CihanOezkan @phranck please add the native part for iOS. See https://c.delta.chat/classdc__context__t.html#a2b5248d480d763bdee55f15e64d02109 for more information. Please append the changes to this branch.
