### PR TITLE
Forward state for messages #337

### DIFF
--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/MessageCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/MessageCallHandler.java
@@ -149,6 +149,9 @@
                 case METHOD_MESSAGE_GET_DURATION:
                     getDuration(methodCall, result);
                     break;
+                case METHOD_MESSAGE_IS_FORWARDED:
+                    isForwarded(methodCall, result);
+                    break;
                 default:
                     result.notImplemented();
             }
@@ -342,6 +345,15 @@
                 return;
             }
             result.success(message.getDuration());
+        }
+
+        private void isForwarded(MethodCall methodCall, MethodChannel.Result result) {
+            DcMsg message = getMessage(methodCall, result);
+            if (message == null) {
+                resultErrorGeneric(methodCall, result);
+                return;
+            }
+            result.success(message.isForwarded());
         }
 
         private DcMsg getMessage(MethodCall methodCall, MethodChannel.Result result) {

--- a/ios/Classes/DCWrapper/DcMsg.swift
+++ b/ios/Classes/DCWrapper/DcMsg.swift
@@ -288,9 +288,13 @@ class DcMsg: MessageType {
     var isSetupMessage: Bool {
         return dc_msg_is_setupmessage(messagePointer) == 1
     }
-
+    
     var isInfoMessage: Bool {
         return dc_msg_is_info(messagePointer) == 1
+    }
+    
+    var isForwaded: Bool {
+        return dc_msg_is_forwarded(messagePointer) == 1
     }
 
     var isOutgoing: Bool {

--- a/ios/Classes/DCWrapper/DcMsg.swift
+++ b/ios/Classes/DCWrapper/DcMsg.swift
@@ -293,7 +293,7 @@ class DcMsg: MessageType {
         return dc_msg_is_info(messagePointer) == 1
     }
     
-    var isForwaded: Bool {
+    var isForwarded: Bool {
         return dc_msg_is_forwarded(messagePointer) == 1
     }
 

--- a/ios/Classes/Handler/MessageCallHandler.swift
+++ b/ios/Classes/Handler/MessageCallHandler.swift
@@ -98,6 +98,8 @@ class MessageCallHandler: MethodCallHandling {
             isStarred(methodCall: call, result: result)
         case Method.Message.GET_DURATION:
             getDuration(methodCall: call, result: result)
+        case Method.Message.IS_FORWARDED:
+            isForwarded(methodCall: call, result: result)
         default:
             log.error("Context: Failing for \(call.method)")
             result(FlutterMethodNotImplemented)
@@ -203,6 +205,11 @@ class MessageCallHandler: MethodCallHandling {
     private func getDuration(methodCall: FlutterMethodCall, result: FlutterResult) {
         let msg = getMessage(methodCall: methodCall, result: result)
         result(NSNumber(value: msg.duration))
+    }
+    
+    private func isForwarded(methodCall: FlutterMethodCall, result: FlutterResult) {
+        let msg = getMessage(methodCall: methodCall, result: result)
+        result(NSNumber(value: msg.isForwaded))
     }
 
     // MARK: - Private Helper

--- a/ios/Classes/Handler/MessageCallHandler.swift
+++ b/ios/Classes/Handler/MessageCallHandler.swift
@@ -209,7 +209,7 @@ class MessageCallHandler: MethodCallHandling {
     
     private func isForwarded(methodCall: FlutterMethodCall, result: FlutterResult) {
         let msg = getMessage(methodCall: methodCall, result: result)
-        result(NSNumber(value: msg.isForwaded))
+        result(NSNumber(value: msg.isForwarded))
     }
 
     // MARK: - Private Helper

--- a/lib/src/chatmsg.dart
+++ b/lib/src/chatmsg.dart
@@ -187,6 +187,10 @@ class ChatMsg extends Base {
     return await loadAndGetValue(methodMessageGetDuration);
   }
 
+  Future<bool> isForwarded() async {
+    return await loadAndGetValue(methodMessageIsForwarded);
+  }
+  
   @override
   getDefaultArguments() => <String, dynamic>{Base.argumentId: _id};
 


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/337

**Describe what the problem was / what the new feature is**
The method to get the forwarded state was missing.
Android part:
`static const String methodMessageIsForwarded = "msg_isForwarded";`

```
private void isForwarded(MethodCall methodCall, MethodChannel.Result result) {
  DcMsg message = getMessage(methodCall, result);
  if (message == null) {
    resultErrorGeneric(methodCall, result);
    return;
  }
  result.success(message.isForwarded());
}
```

**Describe your solution**
Added the Android Plugin part. **iOS is still missing and needs to be implemented before merge**.