### PR TITLE
Empty user in group profile after deletion #491

### DIFF
--- a/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
+++ b/android/src/main/java/com/openxchange/deltachatcore/handlers/ContextCallHandler.java
@@ -42,7 +42,10 @@
 
 package com.openxchange.deltachatcore.handlers;
 
+import android.util.Log;
+
 import com.b44t.messenger.DcChat;
+import com.b44t.messenger.DcChatlist;
 import com.b44t.messenger.DcContact;
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcLot;
@@ -407,11 +410,27 @@ public class ContextCallHandler extends com.openxchange.deltachatcore.handlers.A
             resultErrorArgumentMissingValue(result);
             return;
         }
-        boolean deleted = dcContext.deleteContact(contactId);
-        if (deleted) {
+        boolean isDeletable;
+
+        DcChatlist chats = dcContext.getChatlist(dcContext.DC_GCL_NO_SPECIALS, null, contactId);
+        int chatCnt = chats.getCnt();
+
+        if(chatCnt > 0){
+            for (int i = 0; i < chatCnt; i++) {
+                isDeletable = !dcContext.isContactInChat(chats.getChatId(i), contactId);
+                if(!isDeletable){
+                    result.success(false);
+                    return;
+                }
+            }
+        }
+
+        isDeletable = dcContext.deleteContact(contactId);
+
+        if (isDeletable) {
             contactCache.delete(contactId);
         }
-        result.success(deleted);
+        result.success(isDeletable);
     }
 
     private void blockContact(MethodCall methodCall, MethodChannel.Result result) {

--- a/ios/Classes/DCWrapper/DCContext.swift
+++ b/ios/Classes/DCWrapper/DCContext.swift
@@ -170,6 +170,11 @@ class DcContext {
 
         return contactIds
     }
+    
+    func isContactWith(contactId: UInt32, inChat chatId: Int32) -> Bool {
+        let chatContacts = getChatContacts(for: chatId)
+        return chatContacts.contains(contactId)
+    }
 
     /// Returns a DcChat object for the given contact id
     /// - Parameter id: The contact id whose DcContact object should be returned


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/491

**Describe what the problem was / what the new feature is**
After deletion of a contact the group profile view was broken.

**Describe your solution**
In the deleteContact() method we check if the contact is in a group. If the contact is in a group than cancel the deletion. We need to iterate over each chat of the user and call the `dcContext.isContactInChat(chats.getChatId(i), contactId)` method to check if a contact is in the group. The method name "isContactInChat" is a bit misleading because it just checks if the user is in a group (see: [DeltaChat documentation](https://c.delta.chat/classdc__context__t.html#aec6e3c1cecd0e4e4ea99c4fdfbd177cd).

This part needs to be added by the iOS team:
```
boolean isDeletable;

DcChatlist chats = dcContext.getChatlist(dcContext.DC_GCL_NO_SPECIALS, null, contactId);
int chatCnt = chats.getCnt();

if(chatCnt > 0){
    for (int i = 0; i < chatCnt; i++) {
        isDeletable = !dcContext.isContactInChat(chats.getChatId(i), contactId);
        if(!isDeletable){
            result.success(false);
           return;
        }
   }
}
```

**Additional context**
See also this [Pull Request in the app repository](https://github.com/open-xchange/ox-coi/pull/492). It is an modified error String for the group case.
